### PR TITLE
CSS reset & Mono font improvement

### DIFF
--- a/src/assets/styles/fonts.css
+++ b/src/assets/styles/fonts.css
@@ -31,6 +31,7 @@
   font-family: "Departure Mono";
   font-style: normal;
   font-display: fallback;
+  size-adjust: 105%;
   src:
     local("Departure Mono"),
     url("/fonts//DepartureMono-Regular.woff2") format("woff2");

--- a/src/assets/styles/global.css
+++ b/src/assets/styles/global.css
@@ -46,8 +46,6 @@
   --input-padding: 2px 4px;
 
   --font-mono: "Departure Mono", monospace;
-  --font-mono-size-s: 16.5px;
-  --font-mono-size-m: 22px;
   --font-menu: var(--font-mono);
   --font-base: "Recursive", system-ui;
   --menu-transition-duration: 115ms;
@@ -65,6 +63,10 @@
 
 @layer typography {
   body {
+    font-synthesis: none;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
     font-family: var(--font-base);
     font-size: 1rem;
     line-height: 1.75;
@@ -160,13 +162,11 @@
   select,
   textarea {
     font-family: var(--font-mono);
-    font-size: var(--font-mono-size-s);
   }
 
   button,
   a.button {
     font-family: var(--font-mono);
-    font-size: var(--font-mono-size-s);
   }
 
   mark {
@@ -679,6 +679,10 @@
         0.05em 0.05em 0 var(--color-background),
         0.05em 0 0 var(--color-background);
     }
+  }
+
+  abbr {
+    font-variant-caps: all-petite-caps;
   }
 }
 

--- a/src/assets/styles/reset.css
+++ b/src/assets/styles/reset.css
@@ -43,6 +43,7 @@ h1,
 h2,
 h3,
 h4,
+h5,
 button,
 input,
 label {
@@ -53,7 +54,8 @@ label {
 h1,
 h2,
 h3,
-h4 {
+h4,
+h5 {
   text-wrap: balance;
 }
 
@@ -107,4 +109,11 @@ textarea:not([rows]) {
 
 button {
   cursor: pointer;
+}
+
+/* Makes larger text blocks well-balanced */
+p,
+li,
+figcaption {
+  text-wrap: pretty;
 }

--- a/src/components/Balloon.astro
+++ b/src/components/Balloon.astro
@@ -25,7 +25,6 @@ const props = Astro.props;
     margin: var(--_offset) var(--_offset) var(--_bottom-offset);
 
     font-family: var(--font-mono);
-    font-size: var(--font-mono-size-s);
     color: var(--color-balloon-text);
     background-color: var(--color-balloon-bg);
 

--- a/src/components/InputButton.astro
+++ b/src/components/InputButton.astro
@@ -17,7 +17,6 @@ const { class: className, ...rest } = Astro.props;
     position: relative;
     height: var(--input-height);
     font-family: var(--font-mono);
-    font-size: var(--font-mono-size-s);
     color: var(--_text-color);
     border: var(--input-border-size) solid var(--_border-color);
     background: var(--color-input-bg);

--- a/src/components/Menu.astro
+++ b/src/components/Menu.astro
@@ -62,7 +62,6 @@ const currentPath = Astro.url.pathname;
     font-family: var(--font-mono);
     text-transform: uppercase;
     letter-spacing: 0.12em;
-    font-size: var(--font-mono-size-s);
     gap: 1.5em;
     padding: 0;
     margin-block: 2rem 0;

--- a/src/components/Section.astro
+++ b/src/components/Section.astro
@@ -64,7 +64,6 @@ const readMoreInput = `${id.replace(/\s/gi, "-")}-read-more`;
   .read-more {
     & ~ .read-more-label {
       font-family: var(--font-mono);
-      font-size: var(--font-mono-size-s);
       cursor: pointer;
       color: var(--color-link-text);
       font-size: 1rem;

--- a/src/components/tooltips/dialog/TooltipSearchDialog.astro
+++ b/src/components/tooltips/dialog/TooltipSearchDialog.astro
@@ -84,7 +84,6 @@ const { collections, ...rest } = Astro.props;
       > #close-button {
         flex: 0;
         font-family: var(--font-mono);
-        font-size: var(--font-mono-size-s);
         color: var(--color-text);
         background: none;
         border: 0;
@@ -113,7 +112,6 @@ const { collections, ...rest } = Astro.props;
         > li {
           color: var(--color-li-group-text);
           font-family: var(--font-mono);
-          font-size: var(--font-mono-size-s);
         }
       }
 

--- a/src/pages/hello.astro
+++ b/src/pages/hello.astro
@@ -61,7 +61,6 @@ import Button from "@components/Button.astro";
 
   .grid {
     font-family: var(--font-mono);
-    font-size: var(--font-mono-size-s);
     margin-block: 3rem;
     display: grid;
     gap: 1rem;


### PR DESCRIPTION
I have added some future facing CSS reset improvement for larger text blocks. Also i've just learned about size-adjust that is used on the Mono font to properly adjust the sizes according to their documentation.